### PR TITLE
Align coinbase-websocket-feed-router dependency with reactor version

### DIFF
--- a/coinbase-functions/coinbase-ticker-sink/pom.xml
+++ b/coinbase-functions/coinbase-ticker-sink/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>io.streamnative.data.feeds.realtime</groupId>
             <artifactId>coinbase-websocket-feed-router</artifactId>
-            <version>1.0.0</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
coinbase-ticker-sink pinned its dependency on coinbase-websocket-feed-router to 1.0.0, but the reactor builds 1.0.1. Clean builds (e.g. CI) failed because 1.0.0 exists in neither Maven Central nor the reactor; local builds only succeeded due to a stale 1.0.0 jar cached in ~/.m2. Use ${project.version} so the version tracks the reactor and cannot drift again.